### PR TITLE
Revert OpenJFX version to 21.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,8 @@
 		<!-- Version numbers updated 11 Oct 2021 -->
 		<!-- Runtime dependencies -->
 		<controlsfx.version>11.2.0</controlsfx.version>
-		<openjfx.version>21.0.2</openjfx.version>
+		<!-- UI test failures on unix systems with version 20.0.2 -->
+		<openjfx.version>21.0.1</openjfx.version>
 
 		<!-- Test dependencies -->
 		<!-- TestFX 4.0.17 broke the module -->


### PR DESCRIPTION
On Unix systems with version 21.0.2, the OpenJFX version has been reverted to 21.0.1. This change aims to resolve the observed test failures and ensure the proper functionality of the application across all Unix-based systems.